### PR TITLE
Block reboots unless new version is permitted

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,34 @@
+kind: pipeline
+type: kubernetes
+name: default
+
+steps:
+  - name: fetch
+    image: docker:git
+    commands:
+      - git fetch --tags
+
+  - name: docker-tag
+    image: alpine
+    commands:
+      - test "${DRONE_BRANCH}" == "master" && echo -n "latest,${DRONE_COMMIT}," > .tags || true
+      - test -n "${DRONE_BRANCH}" && test "${DRONE_BRANCH}" != "master" && echo -n "${DRONE_BRANCH}," > .tags || true
+      - test -n "${DRONE_TAG}" && echo -n "${DRONE_TAG}," >> .tags || true
+      - sed -i "s/,$//" .tags
+
+  - name: docker-publish
+    image: plugins/docker
+    settings:
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: quay.io/utilitywarehouse/flatcar-toolkit
+      registry: quay.io
+      context: flatcar-toolkit
+      dockerfile: flatcar-toolkit/Dockerfile
+
+trigger:
+  event:
+    exclude:
+      - pull_request

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A Kustomize base for managing [Flatcar Container Linux](https://www.flatcar-linu
 Includes:
 
 - [flatcar-linux-update-operator](https://github.com/kinvolk/flatcar-linux-update-operator)
+- [A DaemonSet](base/namespaced/flatcar-update-ctl.yaml) that controls when nodes are rebooted
+  into newer release versions
 
 ## Usage
 

--- a/base/cluster/flatcar-update-ctl.yaml
+++ b/base/cluster/flatcar-update-ctl.yaml
@@ -1,0 +1,44 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: flatcar-update-ctl
+spec:
+  volumes:
+    - "*"
+  allowedHostPaths:
+    - pathPrefix: "/usr/bin/update_engine_client"
+      readOnly: true
+    - pathPrefix: "/lib64"
+      readOnly: true
+    - pathPrefix: "/var/run/dbus"
+      readOnly: true
+  runAsUser:
+    rule: "RunAsAny"
+  seLinux:
+    rule: "RunAsAny"
+  supplementalGroups:
+    rule: "RunAsAny"
+  fsGroup:
+    rule: "RunAsAny"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flatcar-update-ctl
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - patch
+  - apiGroups:
+      - policy
+    resourceNames:
+      - flatcar-update-ctl
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use

--- a/base/cluster/kustomization.yaml
+++ b/base/cluster/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - flatcar-linux-update-agent.yaml
   - flatcar-linux-update-operator.yaml
+  - flatcar-update-ctl.yaml

--- a/base/namespaced/flatcar-linux-update-operator.yaml
+++ b/base/namespaced/flatcar-linux-update-operator.yaml
@@ -25,7 +25,7 @@ spec:
             - "/bin/update-operator"
             - "--reboot-window-start=22:00"
             - "--reboot-window-length=8h"
-            - "--before-reboot-annotations=flatcar-linux-update.v1.flatcar-linux.net/before-reboot-version-ctl-okay"
+            - "--before-reboot-annotations=flatcar-linux-update.v1.flatcar-linux.net/before-reboot-version-ctl-ok"
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/base/namespaced/flatcar-linux-update-operator.yaml
+++ b/base/namespaced/flatcar-linux-update-operator.yaml
@@ -25,6 +25,7 @@ spec:
             - "/bin/update-operator"
             - "--reboot-window-start=22:00"
             - "--reboot-window-length=8h"
+            - "--before-reboot-annotations=flatcar-linux-update.v1.flatcar-linux.net/before-reboot-version-ctl-okay"
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/base/namespaced/flatcar-update-ctl.yaml
+++ b/base/namespaced/flatcar-update-ctl.yaml
@@ -1,0 +1,57 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: flatcar-update-ctl
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: &name flatcar-update-ctl
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: *name
+    spec:
+      serviceAccountName: *name
+      nodeSelector:
+        flatcar-linux-update.v1.flatcar-linux.net/before-reboot: "true"
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: *name
+          image: quay.io/utilitywarehouse/flatcar-toolkit
+          args:
+            - update-ctl
+          volumeMounts:
+            - mountPath: /usr/bin/update_engine_client
+              name: update-engine-client
+              readOnly: true
+            - mountPath: /var/run/dbus
+              name: var-run-dbus
+              readOnly: true
+            - mountPath: /lib64
+              name: lib64
+              readOnly: true
+          env:
+            - name: DESIRED_VERSION
+              value: "current"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      volumes:
+        - name: update-engine-client
+          hostPath:
+            path: /usr/bin/update_engine_client
+        - name: var-run-dbus
+          hostPath:
+            path: /var/run/dbus
+        - name: lib64
+          hostPath:
+            path: /lib64

--- a/base/namespaced/kustomization.yaml
+++ b/base/namespaced/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - flatcar-linux-update-agent.yaml
   - flatcar-linux-update-operator.yaml
+  - flatcar-update-ctl.yaml

--- a/flatcar-toolkit/Dockerfile
+++ b/flatcar-toolkit/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.13
 
 COPY *.sh /usr/local/bin/
 
-RUN apk --no-cache add curl bash &&\
-  chmod +x /usr/local/bin/*.sh
+RUN apk --no-cache add curl bash \
+  && chmod +x /usr/local/bin/*.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/flatcar-toolkit/Dockerfile
+++ b/flatcar-toolkit/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.13
+
+COPY *.sh /usr/local/bin/
+
+RUN apk --no-cache add curl bash &&\
+  chmod +x /usr/local/bin/*.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/flatcar-toolkit/docker-entrypoint.sh
+++ b/flatcar-toolkit/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec "flatcar-${1}.sh"

--- a/flatcar-toolkit/flatcar-update-ctl.sh
+++ b/flatcar-toolkit/flatcar-update-ctl.sh
@@ -13,7 +13,7 @@ KUBERNETES_SERVICE_HOST="${KUBERNETES_SERVICE_HOST:?"Must set KUBERNETES_SERVICE
 KUBERNETES_SERVICE_PORT="${KUBERNETES_SERVICE_PORT?"Must set KUBERNETES_SERVICE_PORT"}"
 
 ## Optional env vars 
-ANNOTATION_NAME="${ANNOTATION_NAME:-"flatcar-linux-update.v1.flatcar-linux.net/before-reboot-version-ctl-okay"}"
+ANNOTATION_NAME="${ANNOTATION_NAME:-"flatcar-linux-update.v1.flatcar-linux.net/before-reboot-version-ctl-ok"}"
 
 valid_version() {
   local version=$1

--- a/flatcar-toolkit/flatcar-update-ctl.sh
+++ b/flatcar-toolkit/flatcar-update-ctl.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+## Required env vars 
+DESIRED_VERSION="${DESIRED_VERSION:?"Must set DESIRED_VERSION"}"
+# Should be set in the container spec
+NODE_NAME="${NODE_NAME:?"Must set NODE_NAME"}"
+# These should be set in the pod by Kubernetes
+KUBERNETES_SERVICE_HOST="${KUBERNETES_SERVICE_HOST:?"Must set KUBERNETES_SERVICE_HOST"}" 
+KUBERNETES_SERVICE_PORT="${KUBERNETES_SERVICE_PORT?"Must set KUBERNETES_SERVICE_PORT"}"
+
+## Optional env vars 
+ANNOTATION_NAME="${ANNOTATION_NAME:-"flatcar-linux-update.v1.flatcar-linux.net/before-reboot-version-ctl-okay"}"
+
+valid_version() {
+  local version=$1
+  if [[ "${version}" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+get_new_version() {
+  local new_version
+  new_version=$(update_engine_client -status 2>/dev/null | grep ^NEW_VERSION | sed 's/^NEW_VERSION=//g')
+
+  if ! valid_version "${new_version}"; then
+    echo "Error: unexpected value for NEW_VERSION: ${new_version}" >&2
+    exit 1
+  fi
+
+  echo "${new_version}"
+}
+
+new_version=$(get_new_version)
+
+if [[ "${DESIRED_VERSION}" != "current" ]]; then
+  # With the exception of 'current', DESIRED_VERSION should be a valid release
+  # version
+  if ! valid_version "${DESIRED_VERSION}"; then
+    echo "Error: unexpected value for DESIRED_VERSION: ${DESIRED_VERSION}" >&2
+    exit 1
+  fi
+
+  # If the new version is an earlier version than the desired one then reset the
+  # status and check for a newer update. Wait until the update-engine reports the
+  # UPDATE_STATUS_UPDATED_NEED_REBOOT status again.
+  if [[ "${new_version}" != "${DESIRED_VERSION}" ]] &&\
+     [[ "$(printf "%s\n%s" "${new_version}" "${DESIRED_VERSION}" | sort -rV | head -1)" == "${DESIRED_VERSION}" ]]; then
+    echo "Updating to the latest version because the new version (${new_version}) is less than the desired version (${DESIRED_VERSION})" >&2
+    update_engine_client -reset-status
+    update_engine_client -check_for_update
+    while ! update_engine_client -status 2>/dev/null | grep -q "^CURRENT_OP=UPDATE_STATUS_UPDATED_NEED_REBOOT$"; do
+      sleep 3
+    done
+    new_version=$(get_new_version)
+    echo "Finished updating version. New version is: ${new_version}" >&2
+  fi
+fi
+
+if [[ "${new_version}" == "${DESIRED_VERSION}" ]] || [[ "${DESIRED_VERSION}" == "current" ]]; then
+  echo "Patching node with annotation: ${ANNOTATION_NAME}=true" >&2
+  curl -sSf --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+    -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+    -H "Content-Type: application/strategic-merge-patch+json" \
+    -X PATCH \
+    -d "{\"metadata\":{\"annotations\":{\"${ANNOTATION_NAME}\":\"true\"}}}" \
+    "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/nodes/${NODE_NAME}?fieldManager=kubectl-annotate"
+else
+  echo "New version (${new_version}) doesn't match the desired version (${DESIRED_VERSION}). Sleeping indefinitely..." >&2
+fi
+
+while true; do sleep 86400; done


### PR DESCRIPTION
If `NEW_VERSION` is less than `$DESIRED_VERSION` then reset the update-engine status and check for a newer version.

Allow reboot if `NEW_VERSION == $DESIRED_VERSION`.

Always allow a reboot if `$DESIRED_VERSION == "current"`. This provides the possibility of running the DS across all envs for the purposes of parity while still unpinning some envs. It also gives us a quick switch to block reboots if we find an issue.